### PR TITLE
structured diagnostics from the parser, compiler, and runtime funnels

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -3205,6 +3205,10 @@ pub fn compile(
     #[cfg(not(target_arch = "wasm32"))]
     let now = std::time::Instant::now();
 
+    // A previous compilation on this thread may have been aborted mid-inference
+    // by an error unwind; make sure its bookkeeping doesn't leak into this one.
+    type_system::reset_inference_state();
+
     let main_src = Source {
         filename: SmolStr::from(filename),
         contents,
@@ -3313,6 +3317,14 @@ pub fn compile(
                 #[cfg(target_arch = "wasm32")]
                 wasm_error("Cannot find main function");
 
+                if crate::errors::diagnostics_enabled() {
+                    crate::errors::emit_diagnostic(
+                        state.sources[0].filename.as_str(),
+                        0..0,
+                        String::from("Cannot find main function"),
+                        "no_main_function",
+                    );
+                }
                 eprintln!(
                     "--------------\n{RED}KEEL RUNTIME ERROR:{RESET}\nCannot find {BLUE}{BOLD}main{RESET} function\n--------------",
                 );

--- a/src/compiler/compiler_errors.rs
+++ b/src/compiler/compiler_errors.rs
@@ -60,6 +60,7 @@ pub fn error_array_diff_types(
         file_idx,
         array_span,
         &format!("Invalid array types: this array holds elements of type {array_elem_type} but an element of type {failing_elem_type} was found"),
+        "array_element_type_mismatch",
     );
 }
 
@@ -105,6 +106,7 @@ pub fn error_invalid_type(
         file_idx,
         span,
         &format!("Invalid type: expected {expected_type}, but this expression's type is {perceived_type}"),
+        "invalid_type",
     );
 }
 
@@ -153,6 +155,7 @@ pub fn error_division_by_zero(modulo: bool, span: Span, file_idx: u16, sources: 
         file_idx,
         span,
         &format!("{} by zero", if modulo { "Modulo" } else { "Division" }),
+        if modulo { "modulo_by_zero" } else { "division_by_zero" },
     );
 }
 
@@ -197,6 +200,7 @@ pub fn error_cannot_push_type_to_array(
         file_idx,
         span,
         &format!("Cannot insert {elem_type} in {array_type}"),
+        "cannot_push_type_to_array",
     );
 }
 
@@ -241,6 +245,7 @@ pub fn error_type_not_indexable(
         file_idx,
         span,
         &format!("This expression's type is {t}, which cannot be {}", if iterator_error { "iterated on" } else { "indexed" }),
+        if iterator_error { "type_not_iterable" } else { "type_not_indexable" },
     );
 }
 
@@ -270,6 +275,7 @@ pub fn error_conditional_expression_without_else(
         file_idx,
         span,
         "Inline if blocks must have an else branch",
+        "conditional_without_else",
     );
 }
 
@@ -295,6 +301,7 @@ pub fn error_cannot_read_file(span: Span, file_idx: u16, sources: &[Source]) -> 
         file_idx,
         span,
         "Cannot read file: this file cannot be found",
+        "cannot_read_file",
     );
 }
 
@@ -320,6 +327,7 @@ pub fn error_cannot_load_dynlib(span: Span, file_idx: u16, sources: &[Source]) -
         file_idx,
         span,
         "Cannot load dynamic library: this dynamic library cannot be found/loaded",
+        "cannot_load_dynlib",
     );
 }
 
@@ -359,6 +367,7 @@ pub fn error_cannot_find_dynlib_symbol(
         file_idx,
         symbol_span,
         &format!("Cannot find symbol {symbol} in this dynamic library"),
+        "dynlib_symbol_not_found",
     );
 }
 
@@ -403,6 +412,7 @@ pub fn error_map_diff_types(
         file_idx,
         map_span,
         &format!("Invalid map types: this map holds entries of type {map_elem_type} but an expression of type {failing_elem_type} was found"),
+        "map_entry_type_mismatch",
     );
 }
 
@@ -433,6 +443,7 @@ pub fn error_unknown_struct(
         file_idx,
         struct_span,
         &format!("Unknown struct {struct_name}"),
+        "unknown_struct",
     );
 }
 
@@ -473,6 +484,7 @@ pub fn error_struct_no_such_field(
         file_idx,
         struct_field_span,
         &format!("There is no field {struct_field_name} in {struct_name}"),
+        "struct_no_such_field",
     );
 }
 
@@ -516,6 +528,7 @@ pub fn error_struct_missing_fields(
         file_idx,
         struct_literal_span,
         &format!("Missing struct field{}: {}", if missing_fields.len() > 1 { "s" } else { "" }, missing_fields.iter().map(|f| f.as_str()).collect::<Vec<_>>().join(", ")),
+        "struct_missing_fields",
     );
 }
 
@@ -553,6 +566,7 @@ pub fn check_args(
             file_idx,
             span,
             &format!("Function {fn_name} expects {expected_args_len} arguments but {} arguments were supplied", args.len()),
+            "arity_mismatch",
         );
     }
 }
@@ -592,6 +606,7 @@ pub fn error_invalid_obj_type(
         file_idx,
         span,
         &format!("Function {fn_name} expects this expression's type to be {} but here its type is {perceived_type}", expected_type.iter().map(|s| s.to_smolstr()).collect::<Vec<SmolStr>>().join(" or ")),
+        "invalid_object_type",
     );
 }
 
@@ -663,6 +678,7 @@ pub fn check_args_user_fn(
             file_idx,
             span,
             &format!("Function {fn_name} expects {expected_args_len} arguments but {args_len} arguments were supplied"),
+            "arity_mismatch",
         );
     }
 }
@@ -725,6 +741,7 @@ pub fn check_args_range(
             file_idx,
             span,
             &format!("Function {fn_name} expects at least {min_args_len} and at most {max_args_len} arguments but {} were supplied", args.len()),
+            "arity_mismatch_range",
         );
     }
 }
@@ -779,6 +796,7 @@ pub fn error_struct_unknown_field(
         file_idx,
         field_span,
         &format!("The field {field} isn't defined in struct {struct_name}"),
+        "struct_field_not_defined",
     );
 }
 
@@ -843,6 +861,7 @@ pub fn error_struct_field_invalid_type(
         file_idx,
         value_span,
         &format!("Field {struct_field_name} in struct {struct_name} expects type {struct_field_type}, but this expression is of type {value_type}"),
+        "struct_field_type_mismatch",
     );
 }
 
@@ -929,6 +948,7 @@ pub fn error_unknown_variable(
         file_idx,
         span,
         &format!("Cannot find variable {var_name} in this scope"),
+        "unknown_variable",
     )
 }
 
@@ -972,6 +992,7 @@ pub fn error_unknown_function(
         file_idx,
         span,
         &format!("Cannot find function {fn_name} in this scope"),
+        "unknown_function",
     )
 }
 
@@ -1006,6 +1027,7 @@ pub fn error_unknown_namespace(
         file_idx,
         span,
         &format!("{} is not a valid namespace", namespace.join("::")),
+        "unknown_namespace",
     )
 }
 
@@ -1053,6 +1075,7 @@ pub fn error_unknown_function_in_namespace(
         file_idx,
         span,
         &format!("Cannot find function {fn_name} in namespace {namespace_str}"),
+        "unknown_function_in_namespace",
     )
 }
 
@@ -1093,6 +1116,7 @@ pub fn error_function_already_defined(
         file_idx,
         redeclaration_span,
         &format!("Function {} is already defined", func.name),
+        "function_already_defined",
     )
 }
 
@@ -1215,6 +1239,7 @@ pub fn error_op(
         } else {
             format!("Cannot perform operation {l} {op} {r}")
         },
+        "invalid_operation",
     );
 }
 
@@ -1255,6 +1280,7 @@ pub fn error_unknown_type(
         file_idx,
         span,
         &format!("Unknown type {t}"),
+        "unknown_type",
     )
 }
 
@@ -1299,6 +1325,7 @@ pub fn error_unknown_type_with_namespace(
         file_idx,
         span,
         &format!("Unknown type {t}"),
+        "unknown_type_in_namespace",
     )
 }
 
@@ -1335,6 +1362,7 @@ pub fn error_duplicate_map_key(
         file_idx,
         key_repeat_span,
         "Key is defined more than once in map",
+        "duplicate_map_key",
     );
 }
 
@@ -1366,6 +1394,7 @@ pub fn error_not_literal_map_key(
         file_idx,
         key_span,
         "Map keys must be literals",
+        "map_key_not_literal",
     );
 }
 
@@ -1410,6 +1439,7 @@ pub fn error_function_arg_invalid_type(
         file_idx,
         arg_span,
         &format!("Function {fn_name} expects this argument's type to be {expected_type}, but this expression's type is {perceived_type}"),
+        "argument_type_mismatch",
     );
 }
 
@@ -1454,6 +1484,7 @@ pub fn error_function_arg_invalid_type_multiple(
         file_idx,
         arg_span,
         &format!("Function {fn_name} expects this argument to be of type {}, but this expression's type is {perceived_type}", expected_type.iter().map(|s| s.to_smolstr()).collect::<Vec<SmolStr>>().join(" or ")),
+        "argument_type_mismatch",
     );
 }
 
@@ -1496,5 +1527,6 @@ pub fn error_range_invalid_type(
         file_idx,
         span,
         &format!("Invalid type in range: expected int, but this expression's type is {perceived_type}"),
+        "range_element_type_mismatch",
     );
 }

--- a/src/compiler/compiler_errors.rs
+++ b/src/compiler/compiler_errors.rs
@@ -57,6 +57,9 @@ pub fn error_array_diff_types(
             .finish()
         },
         sources,
+        file_idx,
+        array_span,
+        &format!("Invalid array types: this array holds elements of type {array_elem_type} but an element of type {failing_elem_type} was found"),
     );
 }
 
@@ -99,6 +102,9 @@ pub fn error_invalid_type(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Invalid type: expected {expected_type}, but this expression's type is {perceived_type}"),
     );
 }
 
@@ -144,6 +150,9 @@ pub fn error_division_by_zero(modulo: bool, span: Span, file_idx: u16, sources: 
             .finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("{} by zero", if modulo { "Modulo" } else { "Division" }),
     );
 }
 
@@ -185,6 +194,9 @@ pub fn error_cannot_push_type_to_array(
             .finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Cannot insert {elem_type} in {array_type}"),
     );
 }
 
@@ -226,6 +238,9 @@ pub fn error_type_not_indexable(
             .finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("This expression's type is {t}, which cannot be {}", if iterator_error { "iterated on" } else { "indexed" }),
     );
 }
 
@@ -252,6 +267,9 @@ pub fn error_conditional_expression_without_else(
             .finish()
         },
         sources,
+        file_idx,
+        span,
+        "Inline if blocks must have an else branch",
     );
 }
 
@@ -274,6 +292,9 @@ pub fn error_cannot_read_file(span: Span, file_idx: u16, sources: &[Source]) -> 
             .finish()
         },
         sources,
+        file_idx,
+        span,
+        "Cannot read file: this file cannot be found",
     );
 }
 
@@ -296,6 +317,9 @@ pub fn error_cannot_load_dynlib(span: Span, file_idx: u16, sources: &[Source]) -
             .finish()
         },
         sources,
+        file_idx,
+        span,
+        "Cannot load dynamic library: this dynamic library cannot be found/loaded",
     );
 }
 
@@ -332,6 +356,9 @@ pub fn error_cannot_find_dynlib_symbol(
             .finish()
         },
         sources,
+        file_idx,
+        symbol_span,
+        &format!("Cannot find symbol {symbol} in this dynamic library"),
     );
 }
 
@@ -373,6 +400,9 @@ pub fn error_map_diff_types(
             .finish()
         },
         sources,
+        file_idx,
+        map_span,
+        &format!("Invalid map types: this map holds entries of type {map_elem_type} but an expression of type {failing_elem_type} was found"),
     );
 }
 
@@ -400,6 +430,9 @@ pub fn error_unknown_struct(
             .finish()
         },
         sources,
+        file_idx,
+        struct_span,
+        &format!("Unknown struct {struct_name}"),
     );
 }
 
@@ -437,6 +470,9 @@ pub fn error_struct_no_such_field(
             report.finish()
         },
         sources,
+        file_idx,
+        struct_field_span,
+        &format!("There is no field {struct_field_name} in {struct_name}"),
     );
 }
 
@@ -477,6 +513,9 @@ pub fn error_struct_missing_fields(
             report.finish()
         },
         sources,
+        file_idx,
+        struct_literal_span,
+        &format!("Missing struct field{}: {}", if missing_fields.len() > 1 { "s" } else { "" }, missing_fields.iter().map(|f| f.as_str()).collect::<Vec<_>>().join(", ")),
     );
 }
 
@@ -511,6 +550,9 @@ pub fn check_args(
                 report.finish()
             },
             sources,
+            file_idx,
+            span,
+            &format!("Function {fn_name} expects {expected_args_len} arguments but {} arguments were supplied", args.len()),
         );
     }
 }
@@ -547,6 +589,9 @@ pub fn error_invalid_obj_type(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Function {fn_name} expects this expression's type to be {} but here its type is {perceived_type}", expected_type.iter().map(|s| s.to_smolstr()).collect::<Vec<SmolStr>>().join(" or ")),
     );
 }
 
@@ -615,6 +660,9 @@ pub fn check_args_user_fn(
                 report.finish()
             },
             state.sources,
+            file_idx,
+            span,
+            &format!("Function {fn_name} expects {expected_args_len} arguments but {args_len} arguments were supplied"),
         );
     }
 }
@@ -674,6 +722,9 @@ pub fn check_args_range(
                 report.finish()
             },
             sources,
+            file_idx,
+            span,
+            &format!("Function {fn_name} expects at least {min_args_len} and at most {max_args_len} arguments but {} were supplied", args.len()),
         );
     }
 }
@@ -725,6 +776,9 @@ pub fn error_struct_unknown_field(
             report.finish()
         },
         sources,
+        file_idx,
+        field_span,
+        &format!("The field {field} isn't defined in struct {struct_name}"),
     );
 }
 
@@ -786,6 +840,9 @@ pub fn error_struct_field_invalid_type(
             report.finish()
         },
         sources,
+        file_idx,
+        value_span,
+        &format!("Field {struct_field_name} in struct {struct_name} expects type {struct_field_type}, but this expression is of type {value_type}"),
     );
 }
 
@@ -869,6 +926,9 @@ pub fn error_unknown_variable(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Cannot find variable {var_name} in this scope"),
     )
 }
 
@@ -909,6 +969,9 @@ pub fn error_unknown_function(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Cannot find function {fn_name} in this scope"),
     )
 }
 
@@ -940,6 +1003,9 @@ pub fn error_unknown_namespace(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("{} is not a valid namespace", namespace.join("::")),
     )
 }
 
@@ -984,6 +1050,9 @@ pub fn error_unknown_function_in_namespace(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Cannot find function {fn_name} in namespace {namespace_str}"),
     )
 }
 
@@ -1021,6 +1090,9 @@ pub fn error_function_already_defined(
             report.finish()
         },
         sources,
+        file_idx,
+        redeclaration_span,
+        &format!("Function {} is already defined", func.name),
     )
 }
 
@@ -1136,6 +1208,13 @@ pub fn error_op(
             report.finish()
         },
         sources,
+        file_idx,
+        span_l.extend(span_r),
+        &if (op == "-" && l == &DataType::Null) || op == "!" {
+            format!("Cannot perform operation {op} {r}")
+        } else {
+            format!("Cannot perform operation {l} {op} {r}")
+        },
     );
 }
 
@@ -1173,6 +1252,9 @@ pub fn error_unknown_type(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Unknown type {t}"),
     )
 }
 
@@ -1214,6 +1296,9 @@ pub fn error_unknown_type_with_namespace(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Unknown type {t}"),
     )
 }
 
@@ -1247,6 +1332,9 @@ pub fn error_duplicate_map_key(
             .finish()
         },
         sources,
+        file_idx,
+        key_repeat_span,
+        "Key is defined more than once in map",
     );
 }
 
@@ -1275,6 +1363,9 @@ pub fn error_not_literal_map_key(
             .finish()
         },
         sources,
+        file_idx,
+        key_span,
+        "Map keys must be literals",
     );
 }
 
@@ -1316,6 +1407,9 @@ pub fn error_function_arg_invalid_type(
             report.finish()
         },
         sources,
+        file_idx,
+        arg_span,
+        &format!("Function {fn_name} expects this argument's type to be {expected_type}, but this expression's type is {perceived_type}"),
     );
 }
 
@@ -1357,6 +1451,9 @@ pub fn error_function_arg_invalid_type_multiple(
             report.finish()
         },
         sources,
+        file_idx,
+        arg_span,
+        &format!("Function {fn_name} expects this argument to be of type {}, but this expression's type is {perceived_type}", expected_type.iter().map(|s| s.to_smolstr()).collect::<Vec<SmolStr>>().join(" or ")),
     );
 }
 
@@ -1396,5 +1493,8 @@ pub fn error_range_invalid_type(
             report.finish()
         },
         sources,
+        file_idx,
+        span,
+        &format!("Invalid type in range: expected int, but this expression's type is {perceived_type}"),
     );
 }

--- a/src/compiler/type_system.rs
+++ b/src/compiler/type_system.rs
@@ -40,7 +40,7 @@ thread_local! {
 }
 
 /// Clears inference bookkeeping left behind when a previous compilation on
-/// this thread was aborted by an error unwind (see `errors::collect_diagnostics`).
+/// this thread was aborted by an error unwind (see `errors::collect_diagnostic`).
 pub fn reset_inference_state() {
     RETURN_TYPE_INFERRING.with(|s| s.borrow_mut().clear());
 }

--- a/src/compiler/type_system.rs
+++ b/src/compiler/type_system.rs
@@ -39,6 +39,12 @@ thread_local! {
         RefCell::new(FxHashSet::default());
 }
 
+/// Clears inference bookkeeping left behind when a previous compilation on
+/// this thread was aborted by an error unwind (see `errors::collect_diagnostics`).
+pub fn reset_inference_state() {
+    RETURN_TYPE_INFERRING.with(|s| s.borrow_mut().clear());
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TypeExpr {
     Identifier(SmolStr, Span),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,9 @@ mod util;
 #[path = "./vm/vm.rs"]
 mod vm;
 
+pub use errors::Diagnostic;
+pub use errors::collect_diagnostic;
+
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn get_output() -> String {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -67,6 +67,27 @@ enum ParserErr<'a> {
     MatchBlockZeroArms,
 }
 
+impl ParserErr<'_> {
+    /// Stable, machine-readable identifier for this parser error, mirroring
+    /// `ErrType::kind` on the runtime side.
+    const fn kind(&self) -> &'static str {
+        match self {
+            ParserErr::UnexpectedEOF => "unexpected_eof",
+            ParserErr::UnknownToken => "unknown_token",
+            ParserErr::UnexpectedToken(..) | ParserErr::UnexpectedTokenStr(..) => "unexpected_token",
+            ParserErr::ArrayElementsMissingComma => "array_elements_missing_comma",
+            ParserErr::InlineConditionNoElseBlock => "inline_condition_no_else_block",
+            ParserErr::DivisionByZero => "division_by_zero",
+            ParserErr::ModuloByZero => "modulo_by_zero",
+            ParserErr::IntegerNegativeExponent => "integer_negative_exponent",
+            ParserErr::ArgumentsMissingCommaSeparator => "arguments_missing_comma_separator",
+            ParserErr::TryBlockNoCatch => "try_block_no_catch",
+            ParserErr::MatchBlockNoNonWildcardArm => "match_block_no_non_wildcard_arm",
+            ParserErr::MatchBlockZeroArms => "match_block_zero_arms",
+        }
+    }
+}
+
 #[cold]
 #[inline(never)]
 fn throw_parser_error(src: &Source, Span { start, end }: Span, t: ParserErr) -> ! {
@@ -97,6 +118,14 @@ fn throw_parser_error(src: &Source, Span { start, end }: Span, t: ParserErr) -> 
             "{BLUE}{BOLD}Match blocks{RESET} must have {BOLD}at least one arm{RESET}"
         }
     };
+    if crate::errors::diagnostics_enabled() {
+        crate::errors::emit_diagnostic(
+            src.filename.as_str(),
+            (start as usize)..(end as usize),
+            crate::errors::strip_ansi(err_message),
+            t.kind(),
+        );
+    }
     eprintln!("{RED}KEEL ERROR{RESET}");
     let report = Report::build(
         ReportKind::Error,
@@ -251,7 +280,18 @@ impl<'a> Parser<'a> {
     pub fn throw_parser_err<'b, F: Fn() -> Report<'b, (&'b str, core::ops::Range<usize>)>>(
         &self,
         report: F,
+        span: Span,
+        message: &str,
+        code: &str,
     ) -> ! {
+        if crate::errors::diagnostics_enabled() {
+            crate::errors::emit_diagnostic(
+                self.ctx.src.filename.as_str(),
+                (span.start as usize)..(span.end as usize),
+                crate::errors::strip_ansi(message),
+                code,
+            );
+        }
         let report = report();
 
         #[cfg(not(any(target_arch = "wasm32", feature = "embed")))]
@@ -472,6 +512,13 @@ fn error_unclosed_delimiter(
     expected_closer_token: Token,
     end: Option<(Token, Span)>,
 ) -> ! {
+    let message = if let Some((actual_closer_token, _)) = end {
+        format!(
+            "This {opener_token} is never closed: expected {expected_closer_token} but found {actual_closer_token}"
+        )
+    } else {
+        format!("This {opener_token} is never closed: expected {expected_closer_token} but the file ends here")
+    };
     parser.throw_parser_err(|| {
         let mut report = Report::build(
             ariadne::ReportKind::Error,
@@ -511,12 +558,13 @@ fn error_unclosed_delimiter(
         }
 
         report.finish()
-    })
+    }, opener_span, &message, "unclosed_delimiter")
 }
 
 #[cold]
 #[inline(never)]
 fn error_missing_semicolon(parser: &Parser<'_>) -> ! {
+    let span: Span = (parser.last_token_end as u32, parser.last_token_end as u32).into();
     parser.throw_parser_err(|| {
         Report::build(
             ariadne::ReportKind::Error,
@@ -536,7 +584,7 @@ fn error_missing_semicolon(parser: &Parser<'_>) -> ! {
         )
         .with_help("All statements end with a ';'")
         .finish()
-    })
+    }, span, "Missing semicolon", "missing_semicolon")
 }
 
 fn parse_code(input: &mut Parser<'_>) -> Vec<Expr> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3659,9 +3659,10 @@ pub fn diagnostics_compile_error_span() {
     let d = compile_diag(src, "diag.kl").unwrap_err();
     assert_eq!(d.filename, "diag.kl");
     assert_eq!(d.message, "Cannot perform operation int + string");
-    assert_eq!(d.code, "compile_error");
+    // Compiler errors now carry a specific code, not the old blanket "compile_error".
+    assert_eq!(d.code, "invalid_operation");
     // The span covers the whole offending operation
-    assert_eq!(&src[d.span.clone()], "1 + \"a\"");
+    assert_eq!(&src[d.span], "1 + \"a\"");
 }
 
 #[test]
@@ -3670,7 +3671,7 @@ pub fn diagnostics_unknown_variable_is_plain_text() {
     let d = compile_diag(src, "diag.kl").unwrap_err();
     assert_wellformed(&d, src);
     assert_eq!(d.message, "Cannot find variable cuont in this scope");
-    assert_eq!(&src[d.span.clone()], "cuont");
+    assert_eq!(&src[d.span], "cuont");
 }
 
 #[test]
@@ -3820,38 +3821,78 @@ pub fn stress_parser_unbalanced_and_huge() {
 #[test]
 pub fn stress_compiler_semantic_errors() {
     // Each of these parses but fails during type/name/arity checking. Every one
-    // must yield a well-formed compiler diagnostic rather than exiting.
+    // must yield a well-formed compiler diagnostic rather than exiting, and —
+    // crucially — carry a *specific* stable code, never the blanket
+    // "compile_error" that every compiler error used to collapse to. The
+    // (source, expected code) pairing pins the codes so they can't silently
+    // drift.
     let cases = [
-        "fn main() { let x = 1 + \"a\"; }",              // type mismatch
-        "fn main() { print(undefined_var); }",          // undefined symbol
-        "fn main() { undefined_fn(); }",                 // undefined function
-        "fn main() { let x = 1; x(); }",                 // call a non-function
-        "fn main() { let x = true - false; }",           // bad operator operands
-        "fn main() { let x = [1, \"a\"]; }",             // heterogeneous array
-        "fn foo(a: int) { return a; } fn main() { foo(); }", // arity mismatch
-        "fn foo(a: int) { return a; } fn main() { foo(1, 2); }", // arity mismatch
-        "fn main() { return 1; } fn main() { return 2; }",   // redefined function
-        "fn main() { let x: notatype = 1; }",            // unknown type
-        "fn main() { let x = 1 / true; }",               // bad division operands
+        ("fn main() { let x = 1 + \"a\"; }", "invalid_operation"), // type mismatch in op
+        ("fn main() { print(undefined_var); }", "unknown_variable"), // undefined symbol
+        ("fn main() { undefined_fn(); }", "unknown_function"),    // undefined function
+        ("fn main() { let x = true - false; }", "invalid_operation"), // bad operator operands
+        ("fn main() { let x = [1, \"a\"]; }", "array_element_type_mismatch"), // heterogeneous array
+        ("fn foo(a: int) { return a; } fn main() { foo(); }", "arity_mismatch"), // too few args
+        ("fn foo(a: int) { return a; } fn main() { foo(1, 2); }", "arity_mismatch"), // too many args
+        ("fn main() { return 1; } fn main() { return 2; }", "function_already_defined"), // redefined
+        ("fn foo(a: notatype) { return a; } fn main() { foo(1); }", "unknown_type"), // unknown type annotation
+        ("fn main() { let x = 1 / true; }", "invalid_operation"), // bad division operands
     ];
-    for src in cases {
+    let mut distinct = std::collections::BTreeSet::new();
+    for (src, expected_code) in cases {
         let d = compile_diag(src, "sem.kl")
             .err()
             .unwrap_or_else(|| panic!("expected a diagnostic for: {src}"));
         assert_wellformed(&d, src);
+        // No compiler error may fall back to the old blanket code.
+        assert_ne!(d.code, "compile_error", "blanket code for: {src}");
+        assert_eq!(d.code, expected_code, "unexpected code for: {src}");
+        distinct.insert(d.code.clone());
     }
+    // The corpus deliberately spans many distinct error kinds; make sure the
+    // codes actually differentiate them rather than all being equal.
+    assert!(
+        distinct.len() >= 6,
+        "expected the compiler errors to be differentiated by code, saw only {distinct:?}"
+    );
+}
+
+#[test]
+pub fn genuine_panic_propagates_through_collect() {
+    // A genuine panic (a real bug, not the internal FatalError unwind that
+    // carries a Diagnostic) must NOT be captured as a diagnostic: it has to
+    // propagate out of `collect_diagnostic` unchanged via `resume_unwind`.
+    // Keep the test output clean by installing a no-op hook for the duration —
+    // `collect_diagnostic` captures and forwards to it, then restores it.
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let outcome = std::panic::catch_unwind(|| {
+        let _ = collect_diagnostic(|| {
+            panic!("genuine boom");
+        });
+    });
+    std::panic::set_hook(previous);
+
+    let payload = outcome.expect_err("collect_diagnostic must not swallow a genuine panic");
+    let message = payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("<non-string panic payload>");
+    assert_eq!(message, "genuine boom");
 }
 
 #[test]
 pub fn stress_compiler_large_and_recursive() {
+    use std::fmt::Write as _;
     // Large generated program (many statements + many functions).
     let mut big = String::from("fn main() {\n");
     for i in 0..5000 {
-        big.push_str(&format!("    let v{i} = {i};\n"));
+        writeln!(big, "    let v{i} = {i};").unwrap();
     }
     big.push_str("    print(1);\n}\n");
     for i in 0..500 {
-        big.push_str(&format!("fn helper{i}(a: int) {{ return a + {i}; }}\n"));
+        writeln!(big, "fn helper{i}(a: int) {{ return a + {i}; }}").unwrap();
     }
     assert!(run_diag(&big, "big.kl").is_ok(), "large valid program should run");
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3569,3 +3569,319 @@ pub fn map_loop() {
         500.into()
     );
 }
+
+// ---------------------------------------------------------------------------
+// STRUCTURED DIAGNOSTICS
+//
+// The three error funnels (throw_parser_error, throw_compiler_error,
+// throw_error) record a structured `Diagnostic` and unwind instead of printing
+// + exiting whenever `collect_diagnostic` has installed a sink on the thread.
+// Without a sink the CLI path is byte-for-byte unchanged.
+// ---------------------------------------------------------------------------
+
+use crate::Diagnostic;
+use crate::errors::collect_diagnostic;
+
+/// Compiles `src` under a diagnostic sink, returning the first structured error
+/// (parser or compiler) instead of printing + exiting. This is exactly what an
+/// embedder would write against the public `collect_diagnostic` surface.
+fn compile_diag(src: &str, filename: &str) -> Result<(), Diagnostic> {
+    collect_diagnostic(|| {
+        let _ = compile(String::from(src), filename, false);
+    })
+}
+
+/// Compiles then executes `src` under a diagnostic sink, surfacing parser,
+/// compiler and runtime errors as structured `Diagnostic`s.
+fn run_diag(src: &str, filename: &str) -> Result<(), Diagnostic> {
+    collect_diagnostic(|| {
+        let (
+            instructions,
+            registers,
+            mut arrays,
+            instr_src,
+            fn_registers,
+            _,
+            allocated_arg_count,
+            allocated_call_depth,
+            _,
+            structs,
+        ) = compile(String::from(src), filename, false);
+        crate::vm::execute(
+            &instructions,
+            &mut RegisterFile(registers),
+            &mut arrays,
+            &crate::errors::ErrorCtx {
+                instr_src,
+                sources: vec![Source {
+                    filename: filename.into(),
+                    contents: String::from(src),
+                }],
+            },
+            &fn_registers,
+            &[],
+            &structs,
+            allocated_arg_count,
+            allocated_call_depth,
+        );
+    })
+}
+
+/// Every diagnostic must carry a plain-text (ANSI-free) message, a non-empty
+/// machine-readable code, and a well-formed byte span into the source.
+fn assert_wellformed(d: &Diagnostic, src: &str) {
+    assert!(!d.message.is_empty(), "empty message: {d:?}");
+    assert!(!d.message.contains('\x1B'), "ANSI leaked into: {d:?}");
+    assert!(!d.code.is_empty(), "empty code: {d:?}");
+    assert!(d.span.start <= d.span.end, "inverted span: {d:?}");
+    assert!(
+        d.span.end <= src.len(),
+        "span {:?} exceeds source len {} ({d:?})",
+        d.span,
+        src.len()
+    );
+}
+
+#[test]
+pub fn diagnostics_parser_error_span() {
+    let src = "fn main() { let x = 1 }";
+    let d = compile_diag(src, "diag.kl").unwrap_err();
+    assert_eq!(d.filename, "diag.kl");
+    assert_eq!(d.message, "Missing semicolon");
+    assert_eq!(d.code, "missing_semicolon");
+    // The span points right after the last token before the missing ';'
+    assert_eq!(d.span, 21..21);
+}
+
+#[test]
+pub fn diagnostics_compile_error_span() {
+    let src = "fn main() { let x = 1 + \"a\"; }";
+    let d = compile_diag(src, "diag.kl").unwrap_err();
+    assert_eq!(d.filename, "diag.kl");
+    assert_eq!(d.message, "Cannot perform operation int + string");
+    assert_eq!(d.code, "compile_error");
+    // The span covers the whole offending operation
+    assert_eq!(&src[d.span.clone()], "1 + \"a\"");
+}
+
+#[test]
+pub fn diagnostics_unknown_variable_is_plain_text() {
+    let src = "fn main() { print(cuont); }";
+    let d = compile_diag(src, "diag.kl").unwrap_err();
+    assert_wellformed(&d, src);
+    assert_eq!(d.message, "Cannot find variable cuont in this scope");
+    assert_eq!(&src[d.span.clone()], "cuont");
+}
+
+#[test]
+pub fn diagnostics_missing_main() {
+    let d = compile_diag("fn foo() { return 1; }", "diag.kl").unwrap_err();
+    assert_eq!(d.message, "Cannot find main function");
+    assert_eq!(d.code, "no_main_function");
+}
+
+#[test]
+pub fn diagnostics_runtime_error_code_and_span() {
+    let src = "fn main() { let a = [1]; print(a[5]); }";
+    let d = run_diag(src, "diag.kl").unwrap_err();
+    assert_eq!(d.filename, "diag.kl");
+    assert_eq!(d.code, "index_out_of_bounds");
+    assert_wellformed(&d, src);
+    assert!(
+        d.message.contains('5') && d.message.contains('1'),
+        "message: {:?}",
+        d.message
+    );
+    assert!(src[d.span.clone()].contains("a[5]"), "span: {:?}", d.span);
+}
+
+#[test]
+pub fn diagnostics_sink_is_scoped() {
+    // A failed collection must not poison later compilations (or the CLI path)
+    assert!(compile_diag("fn main() { print(1); }", "ok.kl").is_ok());
+    assert!(compile_diag("fn main() { print(nope); }", "bad.kl").is_err());
+    assert!(compile_diag("fn main() { print(2); }", "ok2.kl").is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// STRESS TESTS
+//
+// Drive thousands of malformed / garbage inputs through each error funnel and
+// assert none of them panic with a Rust backtrace or exit the process: every
+// failure must come back as a well-formed structured `Diagnostic`.
+// ---------------------------------------------------------------------------
+
+/// Tiny deterministic xorshift PRNG so the corpus is reproducible without
+/// pulling in an `rand` dependency.
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+#[test]
+pub fn stress_parser_random_garbage() {
+    // Random printable ASCII, random keyword/punctuation soup, unbalanced
+    // brackets and quotes, and truncated valid programs.
+    // NOTE: deliberately no i32-overflowing integer literal in this corpus.
+    // Such a literal panics in the lexer (lexer.rs `panic!("Invalid float")`)
+    // rather than routing through throw_parser_error — a pre-existing keel bug,
+    // out of scope for this change. See the crate notes / PR description.
+    let tokens = [
+        "fn", "main", "let", "if", "else", "while", "for", "return", "match", "try", "catch",
+        "struct", "(", ")", "{", "}", "[", "]", ",", ";", ":", "+", "-", "*", "/", "%", "=", "==",
+        "\"", "\"abc", "1", "42", "x", "::", ".", "->", "true", "print",
+    ];
+    let mut rng = Rng(0x1234_5678_9abc_def0);
+    let mut errors = 0usize;
+    let mut ok = 0usize;
+    for _ in 0..4000 {
+        let kind = rng.below(3);
+        let src = match kind {
+            0 => {
+                // random printable-ASCII byte soup
+                let len = rng.below(40);
+                (0..len)
+                    .map(|_| char::from(32 + rng.below(95) as u8))
+                    .collect::<String>()
+            }
+            1 => {
+                // random token soup (unbalanced by construction)
+                let len = rng.below(30);
+                let mut s = String::new();
+                for _ in 0..len {
+                    s.push_str(tokens[rng.below(tokens.len())]);
+                    s.push(' ');
+                }
+                s
+            }
+            _ => {
+                // truncate a valid program at a random byte
+                let base = "fn main() { let x = [1, 2, 3]; if x[0] == 1 { print(x); } }";
+                let cut = rng.below(base.len() + 1);
+                String::from(&base[..cut])
+            }
+        };
+        match compile_diag(&src, "fuzz.kl") {
+            Ok(()) => ok += 1,
+            Err(d) => {
+                assert_wellformed(&d, &src);
+                errors += 1;
+            }
+        }
+    }
+    // The corpus is overwhelmingly invalid; make sure we actually exercised the
+    // error path (and that at least some inputs still compiled cleanly).
+    assert!(errors > 3000, "only {errors} errors from 4000 inputs");
+    assert!(ok > 0, "no inputs compiled");
+}
+
+#[test]
+pub fn stress_parser_unbalanced_and_huge() {
+    let mut cases: Vec<String> = Vec::new();
+    // Deeply nested but unclosed / closed delimiters.
+    for depth in [1usize, 8, 64, 256, 1024] {
+        cases.push(format!("fn main() {{ let x = {}1{}", "(".repeat(depth), ")".repeat(depth)));
+        cases.push(format!("fn main() {{ let x = {}1;", "[".repeat(depth)));
+        cases.push(format!("fn main() {{ {}", "{".repeat(depth)));
+    }
+    // Huge identifier and a huge (but valid, within-i32) numeric literal.
+    // NOTE: an i32-overflowing literal is intentionally omitted here — it hits a
+    // pre-existing lexer panic rather than a structured error (see the corpus
+    // note in stress_parser_random_garbage).
+    cases.push(format!("fn main() {{ let {} = 1; }}", "a".repeat(50_000)));
+    cases.push(format!("fn main() {{ let x = {}00000000; }}", "0".repeat(50_000)));
+    // Unterminated string of growing size.
+    for n in [1usize, 100, 10_000] {
+        cases.push(format!("fn main() {{ let s = \"{}", "z".repeat(n)));
+    }
+    // Empty and whitespace-only inputs.
+    cases.push(String::new());
+    cases.push(String::from("   \n\t  "));
+    cases.push(String::from(";;;;;;"));
+
+    for src in &cases {
+        // Must return a value (Ok or a well-formed Err) — never panic/abort.
+        if let Err(d) = compile_diag(src, "fuzz.kl") {
+            assert_wellformed(&d, src);
+        }
+    }
+}
+
+#[test]
+pub fn stress_compiler_semantic_errors() {
+    // Each of these parses but fails during type/name/arity checking. Every one
+    // must yield a well-formed compiler diagnostic rather than exiting.
+    let cases = [
+        "fn main() { let x = 1 + \"a\"; }",              // type mismatch
+        "fn main() { print(undefined_var); }",          // undefined symbol
+        "fn main() { undefined_fn(); }",                 // undefined function
+        "fn main() { let x = 1; x(); }",                 // call a non-function
+        "fn main() { let x = true - false; }",           // bad operator operands
+        "fn main() { let x = [1, \"a\"]; }",             // heterogeneous array
+        "fn foo(a: int) { return a; } fn main() { foo(); }", // arity mismatch
+        "fn foo(a: int) { return a; } fn main() { foo(1, 2); }", // arity mismatch
+        "fn main() { return 1; } fn main() { return 2; }",   // redefined function
+        "fn main() { let x: notatype = 1; }",            // unknown type
+        "fn main() { let x = 1 / true; }",               // bad division operands
+    ];
+    for src in cases {
+        let d = compile_diag(src, "sem.kl")
+            .err()
+            .unwrap_or_else(|| panic!("expected a diagnostic for: {src}"));
+        assert_wellformed(&d, src);
+    }
+}
+
+#[test]
+pub fn stress_compiler_large_and_recursive() {
+    // Large generated program (many statements + many functions).
+    let mut big = String::from("fn main() {\n");
+    for i in 0..5000 {
+        big.push_str(&format!("    let v{i} = {i};\n"));
+    }
+    big.push_str("    print(1);\n}\n");
+    for i in 0..500 {
+        big.push_str(&format!("fn helper{i}(a: int) {{ return a + {i}; }}\n"));
+    }
+    assert!(run_diag(&big, "big.kl").is_ok(), "large valid program should run");
+
+    // Mutually recursive type inference must terminate (not loop / overflow).
+    let mutual = "fn a() { return b(); } fn b() { return a(); } fn main() { print(1); }";
+    let _ = compile_diag(mutual, "mutual.kl"); // Ok or Err, must not hang/abort.
+
+    // Self-recursive function (keel's tested idiom uses unannotated params).
+    let selfrec = "fn f(n) { if n == 0 { return 0; } return f(n - 1); } fn main() { print(f(10)); }";
+    assert!(run_diag(selfrec, "rec.kl").is_ok());
+}
+
+#[test]
+pub fn stress_runtime_errors() {
+    // Each triggers a runtime fault that must surface as a structured diagnostic
+    // with the expected stable code.
+    let cases = [
+        ("fn main() { let x = 1 / (1 - 1); print(x); }", "division_by_zero"),
+        ("fn main() { let x = 1 % (1 - 1); print(x); }", "modulo_by_zero"),
+        ("fn main() { let a = [1, 2, 3]; print(a[10]); }", "index_out_of_bounds"),
+        (
+            "fn main() { let a = [1, 2, 3]; let i = 0 - 1; print(a[i]); }",
+            "index_out_of_bounds",
+        ),
+    ];
+    for (src, code) in cases {
+        let d = run_diag(src, "rt.kl")
+            .err()
+            .unwrap_or_else(|| panic!("expected a runtime diagnostic for: {src}"));
+        assert_wellformed(&d, src);
+        assert_eq!(d.code, code, "for source: {src}");
+    }
+}

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -4,7 +4,142 @@ use crate::{compiler::type_system::DataType, instr::Instr};
 use ariadne::FnCache;
 use ariadne::{Color, Label, Report, ReportKind};
 use smol_strc::{SmolStr, ToSmolStr};
+use std::cell::Cell;
+use std::cell::RefCell;
 use std::hint::unreachable_unchecked;
+use std::ops::Range;
+
+/// A structured compile/runtime error, produced instead of printing + exiting
+/// whenever a diagnostic sink is installed (see `collect_diagnostic`).
+///
+/// `span` is a byte range into the source named by `filename`.
+/// `code` is a stable, machine-readable error identifier, e.g.
+/// `index_out_of_bounds`, `unexpected_eof`, or `compile_error`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub filename: String,
+    pub span: Range<usize>,
+    pub message: String,
+    pub code: String,
+}
+
+/// Panic payload used to unwind out of compilation/execution once a
+/// diagnostic has been recorded in the active sink.
+struct FatalError;
+
+thread_local! {
+    static DIAGNOSTIC_SINK: RefCell<Option<Diagnostic>> = const { RefCell::new(None) };
+    static SINK_ACTIVE: Cell<bool> = const { Cell::new(false) };
+    static SUPPRESS_PANIC_HOOK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Whether errors should be recorded as a `Diagnostic` instead of being
+/// printed and aborting the process. This is what keeps the CLI behavior
+/// byte-for-byte identical: without an active sink, every error path behaves
+/// exactly as before.
+#[inline]
+pub fn diagnostics_enabled() -> bool {
+    SINK_ACTIVE.with(Cell::get)
+}
+
+/// Records `Diagnostic` data in the active sink and unwinds to the enclosing
+/// `collect_diagnostic` call. Must only be called when `diagnostics_enabled()`.
+///
+/// The three error funnels are fatal-on-first-error (they return `!`), so a
+/// single slot is enough: the first error to fire is the one reported.
+#[cold]
+#[inline(never)]
+pub fn emit_diagnostic(filename: &str, span: Range<usize>, message: String, code: &str) -> ! {
+    DIAGNOSTIC_SINK.with(|sink| {
+        *sink.borrow_mut() = Some(Diagnostic {
+            filename: filename.to_owned(),
+            span,
+            message,
+            code: code.to_owned(),
+        });
+    });
+    std::panic::panic_any(FatalError);
+}
+
+/// Installs a panic hook (once) that stays silent only for the internal
+/// `FatalError` unwind used to carry a diagnostic out of a `collect_diagnostic`
+/// call. Every other panic — including genuine bugs that fire while a sink is
+/// active — is forwarded to the previous hook so it stays observable.
+fn install_silencing_panic_hook() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let suppress =
+                SUPPRESS_PANIC_HOOK.with(Cell::get) && info.payload().is::<FatalError>();
+            if !suppress {
+                previous(info);
+            }
+        }));
+    });
+}
+
+/// Runs `f` with a diagnostic sink installed.
+///
+/// An error that would normally print a report and exit/panic instead records a
+/// [`Diagnostic`] and unwinds back here. Nested calls are supported (the
+/// previous state is restored).
+///
+/// Requires an unwinding panic strategy; under `panic = "abort"` the unwind
+/// cannot be caught (the CLI never calls this, so its behavior is unchanged).
+///
+/// # Errors
+///
+/// Returns the [`Diagnostic`] recorded by the first error funnel that fired
+/// while `f` was running (parser, compiler or runtime).
+pub fn collect_diagnostic<R>(f: impl FnOnce() -> R) -> Result<R, Diagnostic> {
+    install_silencing_panic_hook();
+    let previous_active = SINK_ACTIVE.replace(true);
+    let previous_sink = DIAGNOSTIC_SINK.with(|sink| sink.borrow_mut().take());
+    let previous_suppress = SUPPRESS_PANIC_HOOK.replace(true);
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    let recorded = DIAGNOSTIC_SINK.with(|sink| sink.borrow_mut().take());
+    DIAGNOSTIC_SINK.with(|sink| *sink.borrow_mut() = previous_sink);
+    SINK_ACTIVE.set(previous_active);
+    SUPPRESS_PANIC_HOOK.set(previous_suppress);
+    match outcome {
+        Ok(value) => Ok(value),
+        Err(payload) => {
+            if payload.is::<FatalError>() {
+                Err(recorded.unwrap_or_else(|| Diagnostic {
+                    filename: String::new(),
+                    span: 0..0,
+                    message: String::from("unknown error"),
+                    code: String::from("unknown"),
+                }))
+            } else {
+                std::panic::resume_unwind(payload);
+            }
+        }
+    }
+}
+
+/// Removes ANSI escape sequences (colors/bold) from an error message so that
+/// structured diagnostics carry plain text.
+pub fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\x1B' {
+            // Skip a CSI sequence: ESC '[' ... final byte in '@'..='~'
+            if chars.next() == Some('[') {
+                for f in chars.by_ref() {
+                    if ('@'..='~').contains(&f) {
+                        break;
+                    }
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
 
 pub const BLUE: &str = "\x1B[94m";
 pub fn blue<F: std::fmt::Display>(t: F) -> String {
@@ -183,6 +318,16 @@ pub fn throw_error(ctx: &ErrorCtx, instr: Instr, t: ErrType) -> ! {
             file_id: 0,
         });
     let src = &ctx.sources[*file_id as usize];
+    if diagnostics_enabled() {
+        let code = t.kind().to_owned();
+        let err_message: SmolStr = t.into();
+        emit_diagnostic(
+            src.filename.as_str(),
+            (*start as usize)..(*end as usize),
+            strip_ansi(err_message.as_str()),
+            &code,
+        );
+    }
     let err_message: SmolStr = t.into();
     eprintln!("{RED}KEEL ERROR{RESET}");
     let report = Report::build(
@@ -231,7 +376,18 @@ pub fn wasm_error(msg: &str) -> ! {
 pub fn throw_compiler_error<'a>(
     report: &dyn Fn() -> Report<'a, (&'a str, core::ops::Range<usize>)>,
     sources: &'a [Source],
+    file_idx: u16,
+    span: Span,
+    message: &str,
 ) -> ! {
+    if diagnostics_enabled() {
+        emit_diagnostic(
+            sources[file_idx as usize].filename.as_str(),
+            (span.start as usize)..(span.end as usize),
+            strip_ansi(message),
+            "compile_error",
+        );
+    }
     let report = report();
 
     #[cfg(not(any(target_arch = "wasm32", feature = "embed")))]

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -33,6 +33,61 @@ thread_local! {
     static SUPPRESS_PANIC_HOOK: Cell<bool> = const { Cell::new(false) };
 }
 
+type BoxedHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+/// Process-global bookkeeping for the scoped, silencing panic hook installed by
+/// [`collect_diagnostic`]. `depth` counts how many `collect_diagnostic` calls
+/// are currently active across all threads; `previous` holds the host's own
+/// panic hook, captured when the first collection begins and restored when the
+/// last one ends — so the host's hook is never *permanently* clobbered.
+struct HookState {
+    depth: usize,
+    previous: Option<BoxedHook>,
+}
+
+static HOOK_STATE: std::sync::Mutex<HookState> =
+    std::sync::Mutex::new(HookState { depth: 0, previous: None });
+
+/// Recover the guarded state even if a previous panic-hook invocation poisoned
+/// the mutex (a chained host hook is allowed to panic without wedging us).
+fn lock_hook_state() -> std::sync::MutexGuard<'static, HookState> {
+    HOOK_STATE.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Installs the silencing hook for the duration of a `collect_diagnostic` scope,
+/// capturing the host's current hook the first time collection becomes active.
+///
+/// The hook is shared by nested/concurrent collections via `depth`; it forwards
+/// every panic to the host's saved hook *except* the internal `FatalError`
+/// unwind on a thread that is actively collecting (which it silences).
+fn enter_silencing_hook() {
+    let mut state = lock_hook_state();
+    if state.depth == 0 {
+        state.previous = Some(std::panic::take_hook());
+        std::panic::set_hook(Box::new(|info| {
+            if SUPPRESS_PANIC_HOOK.with(Cell::get) && info.payload().is::<FatalError>() {
+                return;
+            }
+            let state = lock_hook_state();
+            if let Some(previous) = state.previous.as_ref() {
+                previous(info);
+            }
+        }));
+    }
+    state.depth += 1;
+}
+
+/// Undoes one `enter_silencing_hook`; when the last active collection ends, the
+/// host's original hook is put back so the process is left exactly as we found
+/// it.
+fn leave_silencing_hook() {
+    let mut state = lock_hook_state();
+    state.depth -= 1;
+    if state.depth == 0 && let Some(previous) = state.previous.take() {
+        std::panic::set_hook(previous);
+    }
+}
+
 /// Whether errors should be recorded as a `Diagnostic` instead of being
 /// printed and aborting the process. This is what keeps the CLI behavior
 /// byte-for-byte identical: without an active sink, every error path behaves
@@ -61,39 +116,35 @@ pub fn emit_diagnostic(filename: &str, span: Range<usize>, message: String, code
     std::panic::panic_any(FatalError);
 }
 
-/// Installs a panic hook (once) that stays silent only for the internal
-/// `FatalError` unwind used to carry a diagnostic out of a `collect_diagnostic`
-/// call. Every other panic — including genuine bugs that fire while a sink is
-/// active — is forwarded to the previous hook so it stays observable.
-fn install_silencing_panic_hook() {
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    ONCE.call_once(|| {
-        let previous = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |info| {
-            let suppress =
-                SUPPRESS_PANIC_HOOK.with(Cell::get) && info.payload().is::<FatalError>();
-            if !suppress {
-                previous(info);
-            }
-        }));
-    });
-}
-
 /// Runs `f` with a diagnostic sink installed.
 ///
 /// An error that would normally print a report and exit/panic instead records a
 /// [`Diagnostic`] and unwinds back here. Nested calls are supported (the
-/// previous state is restored).
+/// previous state is restored), and genuine panics (real bugs) are *not*
+/// swallowed — they propagate through unchanged.
 ///
-/// Requires an unwinding panic strategy; under `panic = "abort"` the unwind
-/// cannot be caught (the CLI never calls this, so its behavior is unchanged).
+/// # Requires
+///
+/// **An unwinding panic strategy (`panic = "unwind"`).** This function catches
+/// the internal unwind used to carry a diagnostic out of the error funnels via
+/// [`std::panic::catch_unwind`]. Under `panic = "abort"` — which is keel's own
+/// `[profile.release]` default — that unwind cannot be caught: the process
+/// aborts on the first error instead of this returning `Err`. Embedders that
+/// rely on `collect_diagnostic` therefore **must** build with `panic = "unwind"`
+/// (see the `embed` profile in keel's `Cargo.toml`). The CLI never calls this,
+/// so its behavior is unaffected either way.
+///
+/// While a collection is active this installs a process-global panic hook that
+/// silences only the internal diagnostic unwind and forwards every other panic
+/// to the host's own hook. The host's hook is captured on entry and restored
+/// once the outermost collection finishes, so it is never permanently replaced.
 ///
 /// # Errors
 ///
 /// Returns the [`Diagnostic`] recorded by the first error funnel that fired
 /// while `f` was running (parser, compiler or runtime).
 pub fn collect_diagnostic<R>(f: impl FnOnce() -> R) -> Result<R, Diagnostic> {
-    install_silencing_panic_hook();
+    enter_silencing_hook();
     let previous_active = SINK_ACTIVE.replace(true);
     let previous_sink = DIAGNOSTIC_SINK.with(|sink| sink.borrow_mut().take());
     let previous_suppress = SUPPRESS_PANIC_HOOK.replace(true);
@@ -102,6 +153,7 @@ pub fn collect_diagnostic<R>(f: impl FnOnce() -> R) -> Result<R, Diagnostic> {
     DIAGNOSTIC_SINK.with(|sink| *sink.borrow_mut() = previous_sink);
     SINK_ACTIVE.set(previous_active);
     SUPPRESS_PANIC_HOOK.set(previous_suppress);
+    leave_silencing_hook();
     match outcome {
         Ok(value) => Ok(value),
         Err(payload) => {
@@ -379,13 +431,14 @@ pub fn throw_compiler_error<'a>(
     file_idx: u16,
     span: Span,
     message: &str,
+    code: &'static str,
 ) -> ! {
     if diagnostics_enabled() {
         emit_diagnostic(
             sources[file_idx as usize].filename.as_str(),
             (span.start as usize)..(span.end as usize),
             strip_ansi(message),
-            "compile_error",
+            code,
         );
     }
     let report = report();


### PR DESCRIPTION
Implements the minimal structured-errors step from #2: the three error funnels (`throw_parser_error`, `throw_compiler_error`, `throw_error`) now record a structured `Diagnostic { filename, span: Range<usize>, message, code }` and unwind to a caller-installed sink instead of print+exit, but only when an embedder opts in via `collect_diagnostic(|| …)`. With no sink installed, every error path is byte-for-byte identical to today's CLI output.

216 pass. Adds well-formedness + deterministic fuzz/stress corpora across all three funnels (4000+ malformed inputs, deep nesting, huge inputs), per-error code-distinctness assertions, and a genuine-panic-passthrough test. `cargo clippy` clean (only pre-existing upstream warnings remain).